### PR TITLE
Add hubconf.py for compatibility with Torch Hub

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -1,0 +1,1 @@
+from wideresnet import (WideResNet, BasicBlock, NetworkBlock)


### PR DESCRIPTION
Will allow importing the model like so:

```python
model = torch.hub.load(
    'xternalz/WideResNet-pytorch', 
    'WideResNet', 
    depth=28, 
    num_classes=10, 
    widen_factor=2
)
```

Example: https://colab.research.google.com/drive/1CnYutDFEk9SSjdsEeE5nY5SPPZ843MNm?usp=sharing